### PR TITLE
Fix a bug preventing last column of Connect Four from being filled 

### DIFF
--- a/5-blazor/1-complete/ConnectFour/Shared/Board.razor
+++ b/5-blazor/1-complete/ConnectFour/Shared/Board.razor
@@ -12,13 +12,13 @@
 </HeadContent>
 
 <nav>
+	<span title="Click to play a piece" @onclick="() => PlayPiece(0)">🔽</span>
 	<span title="Click to play a piece" @onclick="() => PlayPiece(1)">🔽</span>
 	<span title="Click to play a piece" @onclick="() => PlayPiece(2)">🔽</span>
 	<span title="Click to play a piece" @onclick="() => PlayPiece(3)">🔽</span>
 	<span title="Click to play a piece" @onclick="() => PlayPiece(4)">🔽</span>
 	<span title="Click to play a piece" @onclick="() => PlayPiece(5)">🔽</span>
 	<span title="Click to play a piece" @onclick="() => PlayPiece(6)">🔽</span>
-	<span title="Click to play a piece" @onclick="() => PlayPiece(7)">🔽</span>
 </nav>
 
 <article>

--- a/5-blazor/1-complete/ConnectFour/Shared/Board.razor.css
+++ b/5-blazor/1-complete/ConnectFour/Shared/Board.razor.css
@@ -83,31 +83,31 @@ span.container {
 	box-shadow: 0 0 0 4px var(--player2);
 }
 
-.col1 {
+.col0 {
 	left: calc(0em + 9px);
 }
 
-.col2 {
+.col1 {
 	left: calc(4em + 9px);
 }
 
-.col3 {
+.col2 {
 	left: calc(8em + 9px);
 }
 
-.col4 {
+.col3 {
 	left: calc(12em + 9px);
 }
 
-.col5 {
+.col4 {
 	left: calc(16em + 9px);
 }
 
-.col6 {
+.col5 {
 	left: calc(20em + 9px);
 }
 
-.col7 {
+.col6 {
 	left: calc(24em + 9px);
 }
 

--- a/5-blazor/README.md
+++ b/5-blazor/README.md
@@ -287,13 +287,13 @@ The game logic for Connect Four is not too difficult to program.  We need some c
 
 	```csharp
 	<nav>
+		<span title="Click to play a piece" @onclick="() => PlayPiece(0)">🔽</span>
 		<span title="Click to play a piece" @onclick="() => PlayPiece(1)">🔽</span>
 		<span title="Click to play a piece" @onclick="() => PlayPiece(2)">🔽</span>
 		<span title="Click to play a piece" @onclick="() => PlayPiece(3)">🔽</span>
 		<span title="Click to play a piece" @onclick="() => PlayPiece(4)">🔽</span>
 		<span title="Click to play a piece" @onclick="() => PlayPiece(5)">🔽</span>
 		<span title="Click to play a piece" @onclick="() => PlayPiece(6)">🔽</span>
-		<span title="Click to play a piece" @onclick="() => PlayPiece(7)">🔽</span>
 	</nav>
 	```
 


### PR DESCRIPTION
Changes column numbers to be zero-indexed in `Board.razor` and its css file

Resolves #17 